### PR TITLE
fix(doc): removes sphinx githubpages extension

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,7 +32,7 @@
 # ones.
 extensions = [
     'sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.coverage',
-    'sphinx.ext.viewcode', 'sphinx.ext.githubpages'
+    'sphinx.ext.viewcode'
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
似乎readthedocs 不支持`githubpages.ext`这个插件？
https://readthedocs.org/projects/bearychat/builds/4842650/
